### PR TITLE
feat: Add Dockerfile and CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,18 +95,7 @@ jobs:
         run: echo ${{ steps.docker_build_test.outputs.digest }}
 
       - name: List built images
-        run: printenv && docker images
-
-      - name: Run test program
-        # Need to run not below PWD to have non-root write with GHA
-        run: >-
-          docker run --rm
-          pyhf/cuda:sha-${GITHUB_SHA::8}
-          'git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git && \
-           nvidia-smi && \
-           cd nvidia-gpu-ml-library-test.git && \
-           python jax_detect_GPU.py && \
-           python jax_MNIST.py'
+        run: docker images
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -110,7 +110,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ on:
 jobs:
 
   docker:
-    name: Build and publish Debian images
+    name: Build and publish Docker images
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,142 @@
+name: Docker Images
+
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - v*
+  pull_request:
+    branches:
+    - main
+  schedule:
+    - cron:  '1 0 * * 0'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+
+  docker:
+    name: Build and publish Debian images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        backend: [jax]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=pyhf/cuda
+          VERSION=latest
+          PYHF_VERSION=0.6.1
+          CUDA_VERSION=11.1
+          FULL_TAG=${PYHF_VERSION}-${{ matrix.backend }}-cuda-${CUDA_VERSION}
+          REPO_NAME=${{github.repository}}
+          REPO_NAME_LOWERCASE="${REPO_NAME,,}"
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:${FULL_TAG},${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          # Releases also have GITHUB_REFs that are tags, so reuse VERSION
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${REPO_NAME_LOWERCASE}:latest-stable,ghcr.io/${REPO_NAME_LOWERCASE}:${VERSION}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=repo_name_lowercase::"${REPO_NAME_LOWERCASE}"
+          echo ::set-output name=full_tag::"${FULL_TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test build
+        id: docker_build_test
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          load: true
+          push: false
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_test.outputs.digest }}
+
+      - name: List built images
+        run: docker images
+
+      - name: Run test program
+        # Need to run not below PWD to have non-root write with GHA
+        run: >-
+          docker run --rm
+          pyhf/cuda:sha-${GITHUB_SHA::8}
+          'git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git && \
+           nvidia-smi && \
+           cd nvidia-gpu-ml-library-test.git && \
+           python jax_detect_GPU.py && \
+           python jax_MNIST.py'
+
+      - name: Build and publish to registry
+        # every PR will trigger a push event on main, so check the push event is actually coming from main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
+        id: docker_build_latest
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          tags: |
+            pyhf/cuda:latest
+            pyhf/cuda:${{ steps.prep.outputs.full_tag }}
+            ghcr.io/${{ steps.prep.outputs.repo_name_lowercase }}:latest
+            ghcr.io/${{ steps.prep.outputs.repo_name_lowercase }}:${{ steps.prep.outputs.full_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          push: true
+
+      - name: Build and publish to registry with release tag
+        if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'pyhf/cuda-images'
+        id: docker_build_release
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,7 +95,7 @@ jobs:
         run: echo ${{ steps.docker_build_test.outputs.digest }}
 
       - name: List built images
-        run: docker images
+        run: printenv && docker images
 
       - name: Run test program
         # Need to run not below PWD to have non-root write with GHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 # Thanks Anish (@trickarcher)
 FROM ${BASE_IMAGE} as base
 
+ARG PYHF_VERSION=0.6.1
 # CUDA_VERSION is already set in the base image
 # hadolint ignore=DL3003,SC2102
 RUN apt-get -qq -y update && \
@@ -14,7 +15,7 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/* && \
     python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python3 -m pip --no-cache-dir install pyhf[xmlio,contrib] && \
+    python3 -m pip --no-cache-dir install "pyhf[xmlio,contrib]==${PYHF_VERSION}" && \
     python3 -m pip --no-cache-dir install --upgrade jax jaxlib && \
     export jaxlib_version=$(python3 -c 'import jaxlib; print(jaxlib.__version__)') && \
     export cuda_version=$(echo ${CUDA_VERSION} | cut -d . -f -2 | sed 's/\.//') && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE=nvidia/cuda:10.1-base-ubuntu18.04
+FROM ${BASE_IMAGE} as base
+
+FROM base as builder
+# hadolint ignore=DL3003,SC2102
+RUN apt-get -qq -y update && \
+    apt-get -qq -y install --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-dev \
+        git && \
+    apt-get -y autoclean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python3 -m pip --no-cache-dir jax jaxlib && \
+    python3 -m pip install --upgrade jaxlib==0.1.67+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
+    python3 -m pip list

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
 RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python3 -m pip --no-cache-dir jax jaxlib && \
+    python3 -m pip --no-cache-dir install jax jaxlib && \
     python3 -m pip install --upgrade jaxlib==0.1.67+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
     python3 -m pip list

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 # Thanks Anish (@trickarcher)
-# ARG BASE_IMAGE=nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
-# ARG BASE_IMAGE=nvidia/cuda:10.1-base-ubuntu18.04
 FROM ${BASE_IMAGE} as base
 
-FROM base as builder
+# CUDA_VERSION is already set in the base image
 # hadolint ignore=DL3003,SC2102
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
@@ -14,17 +12,15 @@ RUN apt-get -qq -y update && \
         git && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt/lists/*
-# Try 0.1.57 as for 0.1.67
-# Starting training...
-# 2021-06-01 01:58:28.798857: E external/org_tensorflow/tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_NOT_INITIALIZED
-# 2021-06-01 01:58:28.798884: F external/org_tensorflow/tensorflow/compiler/xla/service/gpu/gemm_algorithm_picker.cc:113] Check failed: stream->parent()->GetBlasGemmAlgorithms(&algorithms)
-# Aborted (core dumped)
-    # python3 -m pip --no-cache-dir install jax jaxlib && \
-    # python3 -m pip --no-cache-dir install --upgrade jax==0.2.7 jaxlib==0.1.57+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
-RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python3 -m pip --no-cache-dir install --upgrade jax jaxlib==0.1.67+cuda111 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
-    python3 -m pip list
-RUN git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git && \
+    rm -rf /var/lib/apt/lists/* && \
+    python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python3 -m pip --no-cache-dir install --upgrade jax jaxlib && \
+    export jaxlib_version=$(python3 -c 'import jaxlib; print(jaxlib.__version__)') && \
+    export cuda_version=$(echo ${CUDA_VERSION} | cut -d . -f -2 | sed 's/\.//') && \
+    echo "jaxlib version: ${jaxlib_version}" && \
+    echo "jaxlib+cuda version: ${jaxlib_version}+cuda${cuda_version}" && \
+    python3 -m pip --no-cache-dir install --upgrade jax jaxlib=="${jaxlib_version}+cuda${cuda_version}" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
+    python3 -m pip list && \
     echo '' >> ~/.bashrc && \
     echo 'alias python=$(command -v python3)' >> ~/.bashrc
+RUN git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
+ARG BASE_IMAGE=nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
 # ARG BASE_IMAGE=nvidia/cuda:10.1-base-ubuntu18.04
 FROM ${BASE_IMAGE} as base
 
@@ -17,3 +17,4 @@ RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python3 -m pip --no-cache-dir install jax jaxlib && \
     python3 -m pip --no-cache-dir install --upgrade jaxlib==0.1.67+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
     python3 -m pip list
+RUN git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
+ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
+# ARG BASE_IMAGE=nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
 # ARG BASE_IMAGE=nvidia/cuda:10.1-base-ubuntu18.04
 FROM ${BASE_IMAGE} as base
 
@@ -19,7 +20,10 @@ RUN apt-get -qq -y update && \
 # 2021-06-01 01:58:28.798884: F external/org_tensorflow/tensorflow/compiler/xla/service/gpu/gemm_algorithm_picker.cc:113] Check failed: stream->parent()->GetBlasGemmAlgorithms(&algorithms)
 # Aborted (core dumped)
     # python3 -m pip --no-cache-dir install jax jaxlib && \
+    # python3 -m pip --no-cache-dir install --upgrade jax==0.2.7 jaxlib==0.1.57+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
 RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python3 -m pip --no-cache-dir install --upgrade jax==0.2.7 jaxlib==0.1.57+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
+    python3 -m pip --no-cache-dir install --upgrade jax jaxlib==0.1.67+cuda111 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
     python3 -m pip list
-RUN git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git
+RUN git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git && \
+    echo '' >> ~/.bashrc && \
+    echo 'alias python=$(command -v python3)' >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN apt-get -qq -y update && \
     rm -rf /var/lib/apt/lists/*
 RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python3 -m pip --no-cache-dir install jax jaxlib && \
-    python3 -m pip install --upgrade jaxlib==0.1.67+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
+    python3 -m pip --no-cache-dir install --upgrade jaxlib==0.1.67+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
     python3 -m pip list

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 FROM ${BASE_IMAGE} as base
 
 ARG PYHF_VERSION=0.6.1
-# CUDA_VERSION is already set in the base image
+# CUDA_VERSION already exists as ENV variable in the base image
 # hadolint ignore=DL3003,SC2102
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/* && \
     python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python3 -m pip --no-cache-dir install pyhf[xmlio,contrib] && \
     python3 -m pip --no-cache-dir install --upgrade jax jaxlib && \
     export jaxlib_version=$(python3 -c 'import jaxlib; print(jaxlib.__version__)') && \
     export cuda_version=$(echo ${CUDA_VERSION} | cut -d . -f -2 | sed 's/\.//') && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=nvidia/cuda:10.1-base-ubuntu18.04
+ARG BASE_IMAGE=nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
+# ARG BASE_IMAGE=nvidia/cuda:10.1-base-ubuntu18.04
 FROM ${BASE_IMAGE} as base
 
 FROM base as builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,13 @@ RUN apt-get -qq -y update && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
+# Try 0.1.57 as for 0.1.67
+# Starting training...
+# 2021-06-01 01:58:28.798857: E external/org_tensorflow/tensorflow/stream_executor/cuda/cuda_blas.cc:226] failed to create cublas handle: CUBLAS_STATUS_NOT_INITIALIZED
+# 2021-06-01 01:58:28.798884: F external/org_tensorflow/tensorflow/compiler/xla/service/gpu/gemm_algorithm_picker.cc:113] Check failed: stream->parent()->GetBlasGemmAlgorithms(&algorithms)
+# Aborted (core dumped)
+    # python3 -m pip --no-cache-dir install jax jaxlib && \
 RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python3 -m pip --no-cache-dir install jax jaxlib && \
-    python3 -m pip --no-cache-dir install --upgrade jaxlib==0.1.67+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
+    python3 -m pip --no-cache-dir install --upgrade jax==0.2.7 jaxlib==0.1.57+cuda101 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
     python3 -m pip list
 RUN git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
+# Thanks Anish (@trickarcher)
 # ARG BASE_IMAGE=nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
 # ARG BASE_IMAGE=nvidia/cuda:10.1-base-ubuntu18.04
 FROM ${BASE_IMAGE} as base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
-# Thanks Anish (@trickarcher)
 FROM ${BASE_IMAGE} as base
 
 ARG PYHF_VERSION=0.6.1
@@ -25,4 +24,9 @@ RUN apt-get -qq -y update && \
     python3 -m pip list && \
     echo '' >> ~/.bashrc && \
     echo 'alias python=$(command -v python3)' >> ~/.bashrc
-RUN git clone https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git
+
+WORKDIR /home/data
+ENV HOME /home
+
+ENTRYPOINT ["/bin/bash", "-l", "-c"]
+CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ image:
 	docker build . \
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 \
+	--build-arg PYHF_VERSION=0.6.1 \
 	-t pyhf/cuda:jax-debug-local \
-	-t pyhf/cuda:cuda-111-jax-debug-local
+	-t pyhf/cuda:0.6.1-cuda-111-jax-debug-local
 	docker system prune -f
 
 image-cuda-101:
@@ -16,5 +17,6 @@ image-cuda-101:
 	docker build . \
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 \
-	-t pyhf/cuda:cuda-101-jax-debug-local
+	--build-arg PYHF_VERSION=0.6.1 \
+	-t pyhf/cuda:0.6.1-cuda-101-jax-debug-local
 	docker system prune -f

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all: image
 
 image:
 	docker pull nvidia/cuda:10.1-base-ubuntu18.04
+	docker pull nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
 	docker build . \
 	-f Dockerfile \
 	-t pyhf/cuda:jax-debug-local

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ image:
 	--build-arg BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 \
 	--build-arg PYHF_VERSION=0.6.1 \
 	-t pyhf/cuda:jax-debug-local \
-	-t pyhf/cuda:0.6.1-cuda-111-jax-debug-local
+	-t pyhf/cuda:0.6.1-jax-cuda-111-debug-local
 	docker system prune -f
 
 image-cuda-101:
@@ -18,5 +18,5 @@ image-cuda-101:
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 \
 	--build-arg PYHF_VERSION=0.5.4 \
-	-t pyhf/cuda:0.5.4-cuda-101-jax-debug-local
+	-t pyhf/cuda:0.5.4-jax-cuda-101-debug-local
 	docker system prune -f

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+default: image
+
+all: image
+
+image:
+	docker build . \
+	-f Dockerfile \
+	-t pyhf/cuda:jax-debug-local

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: image
 
 image:
 	docker pull nvidia/cuda:10.1-base-ubuntu18.04
-	docker pull nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
+	docker pull nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
 	docker build . \
 	-f Dockerfile \
 	-t pyhf/cuda:jax-debug-local

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,18 @@ default: image
 all: image
 
 image:
-	docker pull nvidia/cuda:10.1-base-ubuntu18.04
-	docker pull nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
+	docker pull nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 	docker build . \
 	-f Dockerfile \
-	-t pyhf/cuda:jax-debug-local
+	--build-arg BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 \
+	-t pyhf/cuda:jax-debug-local \
+	-t pyhf/cuda:cuda-111-jax-debug-local
+	docker system prune -f
+
+image-cuda-101:
+	docker pull nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
+	docker build . \
+	-f Dockerfile \
+	--build-arg BASE_IMAGE=nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 \
+	-t pyhf/cuda:cuda-101-jax-debug-local
+	docker system prune -f

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,6 @@ image-cuda-101:
 	docker build . \
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 \
-	--build-arg PYHF_VERSION=0.6.1 \
-	-t pyhf/cuda:0.6.1-cuda-101-jax-debug-local
+	--build-arg PYHF_VERSION=0.5.4 \
+	-t pyhf/cuda:0.5.4-cuda-101-jax-debug-local
 	docker system prune -f

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ default: image
 all: image
 
 image:
+	docker pull nvidia/cuda:10.1-base-ubuntu18.04
 	docker build . \
 	-f Dockerfile \
 	-t pyhf/cuda:jax-debug-local

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ image:
 	--build-arg BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 \
 	--build-arg PYHF_VERSION=0.6.1 \
 	-t pyhf/cuda:jax-debug-local \
-	-t pyhf/cuda:0.6.1-jax-cuda-111-debug-local
+	-t pyhf/cuda:0.6.1-jax-cuda-11.1-debug-local
 	docker system prune -f
 
 image-cuda-101:
@@ -18,5 +18,5 @@ image-cuda-101:
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 \
 	--build-arg PYHF_VERSION=0.5.4 \
-	-t pyhf/cuda:0.5.4-jax-cuda-101-debug-local
+	-t pyhf/cuda:0.5.4-jax-cuda-10.1-debug-local
 	docker system prune -f

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# cuda-images
-pyhf Docker images built on Nvidia Container Toolkit enabled base images
+# `pyhf` NVIDIA CUDA enabled Docker images
+
+
+[`pyhf`](https://pyhf.readthedocs.io/) Docker images built on the [NVIDIA CUDA enabled images](https://github.com/NVIDIA/nvidia-docker) for runtime use with the the NVIDIA Container Toolkit.
+
+[![Docker Images](https://github.com/pyhf/cuda-images/actions/workflows/docker.yml/badge.svg?branch=main)](https://github.com/pyhf/cuda-images/actions/workflows/docker.yml?query=branch%3Amain)
+[![Docker Pulls](https://img.shields.io/docker/pulls/pyhf/cuda.svg)](https://hub.docker.com/r/pyhf/cuda/)
+
+
+## Installation
+
+- Make sure that you have the [`nvidia-container-toolkit`](https://github.com/NVIDIA/nvidia-docker) installed on the host machine
+- Check the [list of available tags on Docker Hub](https://hub.docker.com/r/pyhf/cuda/tags?page=1) to find the tag you want
+- Use `docker pull` to pull down the image corresponding to the tag
+
+Example:
+
+```
+docker pull pyhf/cuda:0.6.1-jax-cuda-11.1
+```
+
+## Use
+
+To check that NVIDIA GPUS are being properly detected run
+
+```
+docker run --rm --gpus all pyhf/cuda:0.6.1-jax-cuda-11.1 'nvidia-smi'
+```
+
+and check if the [`nvidia-smi`](https://developer.nvidia.com/nvidia-system-management-interface) output appears correctly.
+
+To run (interactively) using GPUs on the host machine:
+
+```
+docker run --rm -ti --gpus all pyhf/cuda:0.6.1-jax-cuda-11.1

--- a/minimal-failing.py
+++ b/minimal-failing.py
@@ -1,4 +1,0 @@
-from jax import random
-
-if __name__ == "__main__":
-    rng = random.PRNGKey(0)

--- a/minimal-failing.py
+++ b/minimal-failing.py
@@ -1,0 +1,4 @@
+from jax import random
+
+if __name__ == "__main__":
+    rng = random.PRNGKey(0)


### PR DESCRIPTION
Add Dockerfile for JAX CUDA enabled pyhf backend images. To support access to GPUs and CUDA runtimes, the images are built off the `nvidia/cuda` Docker images and for the JAX backend the `nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04` image is used as a base image. (Thanks to @trickarcher for pointing out that the `devel` tag series of images is _required_ for use of CUDA libraries at runtime (NOT the `runtime` tag series))

> Hi, you need to use the `nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04` as `BASE_IMAGE` in your `Dockerfile` instead of the `runtime` image. The `runtime` image does not contain the `cuda` compiler , which is needed by `JAX`.
> ...
>I think it's more of a XLA thing, which both JAX and TF use. And XLA in-turn heavily relies on intenal cuda compiler shared libraries and header files. Using devel images is probably the only way to get those files. Glad to know it works!

```
* Add Dockerfile for JAX CUDA enabled pyhf backend
   - Based on nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 images
   - Thanks to Anish Biswas (@trickarcher) for debugging help
* Add CI/CD with deployments to Docker Hub and GitHub Container Registry
* Add Makefile for local debugging
* Add relevant details to README
```