### PR TITLE
fix: Symlink python3 to 'python'

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,5 +1,0 @@
-# .bash_profile
-# Get the aliases and functions
-if [ -f ~/.bashrc ]; then
-      . ~/.bashrc
-fi

--- a/.bash_profile
+++ b/.bash_profile
@@ -1,0 +1,5 @@
+# .bash_profile
+# Get the aliases and functions
+if [ -f ~/.bashrc ]; then
+      . ~/.bashrc
+fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 FROM ${BASE_IMAGE} as base
 
-COPY .bash_profile /root/.bash_profile
 WORKDIR /home/data
 
 ARG PYHF_VERSION=0.6.1
@@ -25,6 +24,7 @@ RUN apt-get -qq -y update && \
     echo "jaxlib+cuda version: ${jaxlib_version}+cuda${cuda_version}" && \
     python3 -m pip --no-cache-dir install --upgrade jax jaxlib=="${jaxlib_version}+cuda${cuda_version}" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
     python3 -m pip list && \
+    ln --symbolic $(command -v python3) /usr/bin/python && \
     echo '' >> ~/.bashrc && \
     echo 'alias python=$(command -v python3)' >> ~/.bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 FROM ${BASE_IMAGE} as base
 
+COPY .bash_profile /root/.bash_profile
+WORKDIR /home/data
+
 ARG PYHF_VERSION=0.6.1
 # CUDA_VERSION already exists as ENV variable in the base image
 # hadolint ignore=DL3003,SC2102
@@ -24,9 +27,6 @@ RUN apt-get -qq -y update && \
     python3 -m pip list && \
     echo '' >> ~/.bashrc && \
     echo 'alias python=$(command -v python3)' >> ~/.bashrc
-
-WORKDIR /home/data
-ENV HOME /home
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ docker run --rm -ti --gpus all pyhf/cuda:0.6.1-jax-cuda-11.1
 To verify things are working on your host machine you can run
 
 ```
-docker run --rm --gpus all -v $PWD:$PWD -w $PWD pyhf/cuda:0.6.1-jax-cuda-11.1-debug-local 'bash tests/test_jax.sh'
+docker run --rm --gpus all -v $PWD:$PWD -w $PWD pyhf/cuda:0.6.1-jax-cuda-11.1 'bash tests/test_jax.sh'
 ```

--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ To run (interactively) using GPUs on the host machine:
 
 ```
 docker run --rm -ti --gpus all pyhf/cuda:0.6.1-jax-cuda-11.1
+```
+
+## Tests
+
+To verify things are working on your host machine you can run
+
+```
+docker run --rm --gpus all -v $PWD:$PWD -w $PWD pyhf/cuda:0.6.1-jax-cuda-11.1-debug-local 'bash tests/test_jax.sh'
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [`pyhf`](https://pyhf.readthedocs.io/) Docker images built on the [NVIDIA CUDA enabled images](https://github.com/NVIDIA/nvidia-docker) for runtime use with the the NVIDIA Container Toolkit.
 
+**These images are meant to be used as base images for bespoke user application images to build on.**
+
 [![Docker Images](https://github.com/pyhf/cuda-images/actions/workflows/docker.yml/badge.svg?branch=main)](https://github.com/pyhf/cuda-images/actions/workflows/docker.yml?query=branch%3Amain)
 [![Docker Pulls](https://img.shields.io/docker/pulls/pyhf/cuda.svg)](https://hub.docker.com/r/pyhf/cuda/)
 

--- a/tests/test_jax.sh
+++ b/tests/test_jax.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 if [[ ! -d nvidia-gpu-ml-library-test ]];then
     git clone --depth 1 https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git

--- a/tests/test_jax.sh
+++ b/tests/test_jax.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+if [[ ! -d nvidia-gpu-ml-library-test ]];then
+    git clone --depth 1 https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git
+fi
+cd nvidia-gpu-ml-library-test || exit
+python jax_detect_GPU.py
+python jax_MNIST.py

--- a/tests/test_jax.sh
+++ b/tests/test_jax.sh
@@ -4,5 +4,10 @@ if [[ ! -d nvidia-gpu-ml-library-test ]];then
     git clone --depth 1 https://github.com/matthewfeickert/nvidia-gpu-ml-library-test.git
 fi
 cd nvidia-gpu-ml-library-test || exit
+
+printf "\n# nvidia-smi --list-gpus\n"
+nvidia-smi --list-gpus
+printf "\n# python jax_detect_GPU.py\n"
 python jax_detect_GPU.py
+printf "\n# python jax_MNIST.py\n"
 python jax_MNIST.py


### PR DESCRIPTION
```
* Use symbolic links to ensure that python -> python3 regardless of if in interactive session or not
* Revert default $HOME to /root
   - Users can use this as a base image for a specialized image
* Add use tests for JAX images
* Note in README these are base images
```