### PR TITLE
refactor: Install pip through bootstrap.pypa.io virtualenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ FROM ${BASE_IMAGE} as base
 WORKDIR /home/data
 
 ARG PYHF_VERSION=0.6.1
+# Set PATH now to pickup virtualenv when it is unpacked here
+ENV PATH=/usr/local/venv/bin:"${PATH}"
 # CUDA_VERSION already exists as ENV variable in the base image
 # hadolint ignore=DL3003,SC2102
 RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         python3 \
-        python3-pip \
         python3-dev \
         git && \
     apt-get -y autoclean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,18 +17,19 @@ RUN apt-get -qq -y update && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/* && \
-    python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python3 -m pip --no-cache-dir install "pyhf[xmlio,contrib]==${PYHF_VERSION}" && \
-    python3 -m pip --no-cache-dir install --upgrade jax jaxlib && \
-    export jaxlib_version=$(python3 -c 'import jaxlib; print(jaxlib.__version__)') && \
+    curl --silent --location --remote-name https://bootstrap.pypa.io/virtualenv.pyz && \
+    python3 virtualenv.pyz /usr/local/venv && \
+    rm virtualenv.pyz && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install virtualenv && \
+    python -m pip --no-cache-dir install "pyhf[xmlio,contrib]==${PYHF_VERSION}" && \
+    python -m pip --no-cache-dir install --upgrade jax jaxlib && \
+    export jaxlib_version=$(python -c 'import jaxlib; print(jaxlib.__version__)') && \
     export cuda_version=$(echo ${CUDA_VERSION} | cut -d . -f -2 | sed 's/\.//') && \
     echo "jaxlib version: ${jaxlib_version}" && \
     echo "jaxlib+cuda version: ${jaxlib_version}+cuda${cuda_version}" && \
-    python3 -m pip --no-cache-dir install --upgrade jax jaxlib=="${jaxlib_version}+cuda${cuda_version}" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
-    python3 -m pip list && \
-    ln --symbolic $(command -v python3) /usr/bin/python && \
-    echo '' >> ~/.bashrc && \
-    echo 'alias python=$(command -v python3)' >> ~/.bashrc
+    python -m pip --no-cache-dir install --upgrade jax jaxlib=="${jaxlib_version}+cuda${cuda_version}" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html && \
+    python -m pip list
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get -qq -y update && \
     python3 virtualenv.pyz /usr/local/venv && \
     rm virtualenv.pyz && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python -m pip --no-cache-dir install virtualenv && \
     python -m pip --no-cache-dir install "pyhf[xmlio,contrib]==${PYHF_VERSION}" && \
     python -m pip --no-cache-dir install --upgrade jax jaxlib && \
     export jaxlib_version=$(python -c 'import jaxlib; print(jaxlib.__version__)') && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE} as base
 WORKDIR /home/data
 
 ARG PYHF_VERSION=0.6.1
-# Set PATH now to pickup virtualenv when it is unpacked here
+# Set PATH to pickup virtualenv when it is unpacked
 ENV PATH=/usr/local/venv/bin:"${PATH}"
 # CUDA_VERSION already exists as ENV variable in the base image
 # hadolint ignore=DL3003,SC2102

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qq -y update && \
     apt-get -qq -y install --no-install-recommends \
         python3 \
         python3-dev \
+        curl \
         git && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \


### PR DESCRIPTION
Greatly simplify setup by installing `pip` through downloading it from https://bootstrap.pypa.io/virtualenv.pyz and then unpacking it in `PATH`. This has the added benefit of symlinking the installed `python3` to the `virtualenv` PATH, so something like

```
ln -s $(command -v python3) /usr/local/venv/bin/python
```
, which then very nicely means that `python` gives you `python3` regardless of if the session is interactive or not.

This approach was recommended by Anthony Sottile in his YouTube video "[how to get pip for deadsnakes / docker pythons (intermediate) anthony explains 293](https://youtu.be/2Hg5-Hrsa6w)". Thanks Anthony!

```
* Install pip through downloading from the PyPA's bootstrap virtualenv and add virtualenv to PATH
   - Installation of virtualenv also symlinks the python doing the installing to virtualenv's python. This is an improvement over the approach in PR #2
   - Thanks to Anthony Sottile (@asottile) for recommending this approach
   - c.f. https://youtu.be/2Hg5-Hrsa6w
```