### PR TITLE
ci: Replace image tag 'latest' with latest by backend

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,10 +45,10 @@ jobs:
             VERSION=pr-${{ github.event.number }}
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
-          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:${FULL_TAG},${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest-${{ matrix.backend }},${DOCKER_IMAGE}:${FULL_TAG},${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
           # Releases also have GITHUB_REFs that are tags, so reuse VERSION
           if [ "${{ github.event_name }}" = "release" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${REPO_NAME_LOWERCASE}:latest-stable,ghcr.io/${REPO_NAME_LOWERCASE}:${VERSION}"
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable-${{ matrix.backend }},ghcr.io/${REPO_NAME_LOWERCASE}:latest-stable-${{ matrix.backend }},ghcr.io/${REPO_NAME_LOWERCASE}:${VERSION}"
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
@@ -106,9 +106,9 @@ jobs:
           context: .
           file: Dockerfile
           tags: |
-            pyhf/cuda:latest
+            pyhf/cuda:latest-${{ matrix.backend }}
             pyhf/cuda:${{ steps.prep.outputs.full_tag }}
-            ghcr.io/${{ steps.prep.outputs.repo_name_lowercase }}:latest
+            ghcr.io/${{ steps.prep.outputs.repo_name_lowercase }}:latest-${{ matrix.backend }}
             ghcr.io/${{ steps.prep.outputs.repo_name_lowercase }}:${{ steps.prep.outputs.full_tag }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         id: prep
         run: |
           DOCKER_IMAGE=pyhf/cuda
-          VERSION=latest
+          VERSION=latest-${{ matrix.backend }}
           PYHF_VERSION=0.6.1
           CUDA_VERSION=11.1
           FULL_TAG=${PYHF_VERSION}-${{ matrix.backend }}-cuda-${CUDA_VERSION}


### PR DESCRIPTION
```
* Replace image tag 'latest' with latest-backend for each pyhf backend
   - e.g. latest -> latest-jax
   - This reduces confusion on the meaning of 'latest' and also ensures that one backend isn't favored over others
```