### PR TITLE
feat: Add backend installer Bash script

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,6 +84,8 @@ jobs:
           context: .
           file: Dockerfile
           tags: ${{ steps.prep.outputs.tags }}
+          build-args: |
+            PYHF_BACKEND=${{ matrix.backend }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
@@ -105,6 +107,8 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          build-args: |
+            PYHF_BACKEND=${{ matrix.backend }}
           tags: |
             pyhf/cuda:latest-${{ matrix.backend }}
             pyhf/cuda:${{ steps.prep.outputs.full_tag }}
@@ -123,6 +127,8 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          build-args: |
+            PYHF_BACKEND=${{ matrix.backend }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 FROM ${BASE_IMAGE} as base
 
+SHELL [ "/bin/bash", "-c" ]
+
 WORKDIR /home/data
 
 ARG PYHF_VERSION=0.6.1

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ image:
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 \
 	--build-arg PYHF_VERSION=0.6.1 \
+	--build-arg PYHF_BACKEND=jax \
 	-t pyhf/cuda:jax-debug-local \
 	-t pyhf/cuda:0.6.1-jax-cuda-11.1-debug-local
 	docker system prune -f
@@ -18,5 +19,6 @@ image-cuda-101:
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 \
 	--build-arg PYHF_VERSION=0.5.4 \
+	--build-arg PYHF_BACKEND=jax \
 	-t pyhf/cuda:0.5.4-jax-cuda-10.1-debug-local
 	docker system prune -f

--- a/install_backend.sh
+++ b/install_backend.sh
@@ -30,7 +30,7 @@ function main() {
     elif [[ "${pyhf_backend_name}" =~ ^("tensorflow"|"tf")$ ]]; then
         # TODO: Impliment
         # install_tensorflow_backend
-        echo "tensorflow"
+        exit 1
     fi
 }
 

--- a/install_backend.sh
+++ b/install_backend.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# CUDA_VERSION already exists as ENV variable in the base image
+
 function install_jax_backend {
     local jaxlib_version
     local cuda_version

--- a/install_backend.sh
+++ b/install_backend.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+function install_jax_backend {
+    local jaxlib_version
+    local cuda_version
+
+    python -m pip --no-cache-dir install --upgrade jax jaxlib
+    jaxlib_version=$(python -c 'import jaxlib; print(jaxlib.__version__)')
+    # shellcheck disable=SC2153
+    cuda_version=$(echo "${CUDA_VERSION}" | cut -d . -f -2 | sed 's/\.//')
+    echo "jaxlib version: ${jaxlib_version}"
+    echo "jaxlib+cuda version: ${jaxlib_version}+cuda${cuda_version}"
+    python -m pip --no-cache-dir install --upgrade jax jaxlib=="${jaxlib_version}+cuda${cuda_version}" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
+}
+
+function main() {
+    # 1: pyhf backend name
+
+    pyhf_backend_name=""
+    if [[ $# -gt 0 ]];then
+        pyhf_backend_name=$(echo "${1}" | awk '{print tolower($0)}')
+    fi
+
+    if [[ "${pyhf_backend_name}" = "jax" ]]; then
+        install_jax_backend
+    elif [[ "${pyhf_backend_name}" =~ ^("pytorch"|"torch")$ ]]; then
+        # TODO: Impliment
+        # install_pytorch_backend
+        exit 1
+    elif [[ "${pyhf_backend_name}" =~ ^("tensorflow"|"tf")$ ]]; then
+        # TODO: Impliment
+        # install_tensorflow_backend
+        echo "tensorflow"
+    fi
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
Add backend installer script to move backend selection logic from Dockerfile to Bash script.

```
* Add backend installer Bash script
   - Move logic of pyhf backend selection and installation out of Dockerfile and into Bash script to simplify core Dockerfile
   - Add option to install JAX and implement PyTorch and TensorFlow installation in future
* Add Docker build-arg 'PYHF_BACKEND'
* Set PYHF_BACKEND in CI from build matrix value
```