### PR TITLE
ci: Add torch and base image as build matrix option

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,12 +23,12 @@ jobs:
     strategy:
       matrix:
         backend: [jax, torch]
-        base-image: [nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04, nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04]
+        base-image: ["nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04", "nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04"]
         exclude:
           - backend: jax
-            base-image: nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04
+            base-image: "nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04"
           - backend: torch
-            base-image: nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
+            base-image: "nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04"
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        backend: [jax]
+        backend: [jax, torch]
+        base-image: [nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04, nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04]
+        exclude:
+          - backend: jax
+            base-image: nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04
+          - backend: torch 
+            base-image: nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 
     steps:
       - name: Checkout
@@ -85,6 +91,7 @@ jobs:
           file: Dockerfile
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |
+            BASE_IMAGE=${{ matrix.base-image }}
             PYHF_BACKEND=${{ matrix.backend }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
@@ -108,6 +115,7 @@ jobs:
           context: .
           file: Dockerfile
           build-args: |
+            BASE_IMAGE=${{ matrix.base-image }}
             PYHF_BACKEND=${{ matrix.backend }}
           tags: |
             pyhf/cuda:latest-${{ matrix.backend }}
@@ -128,6 +136,7 @@ jobs:
           context: .
           file: Dockerfile
           build-args: |
+            BASE_IMAGE=${{ matrix.base-image }}
             PYHF_BACKEND=${{ matrix.backend }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,10 +23,10 @@ jobs:
     strategy:
       matrix:
         backend: [jax, torch]
-        base-image: ["nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04", "nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04"]
+        base-image: ["nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04", "nvidia/cuda:11.1-base-ubuntu20.04"]
         exclude:
           - backend: jax
-            base-image: "nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04"
+            base-image: "nvidia/cuda:11.1-base-ubuntu20.04"
           - backend: torch
             base-image: "nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    # branches:
-    # - main
-    # tags:
-    # - v*
+    branches:
+    - main
+    tags:
+    - v*
   pull_request:
     branches:
     - main
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker Images
 
 on:
   push:
-    branches:
-    - main
-    tags:
-    - v*
+    # branches:
+    # - main
+    # tags:
+    # - v*
   pull_request:
     branches:
     - main
@@ -27,7 +27,7 @@ jobs:
         exclude:
           - backend: jax
             base-image: nvidia/cuda:11.1-cudnn8-runtime-ubuntu20.04
-          - backend: torch 
+          - backend: torch
             base-image: nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
 
     steps:
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'pyhf/cuda-images'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ image:
 	docker system prune -f
 
 image-torch:
-	docker pull nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04
+	docker pull nvidia/cuda:11.1-base-ubuntu20.04
 	docker build . \
 	-f Dockerfile \
-	--build-arg BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 \
+	--build-arg BASE_IMAGE=nvidia/cuda:11.1-base-ubuntu20.04 \
 	--build-arg PYHF_VERSION=0.6.1 \
 	--build-arg PYHF_BACKEND=torch \
 	-t pyhf/cuda:0.6.1-torch-cuda-11.1-debug-local


### PR DESCRIPTION
To overcome the problems of PR #7, rely on the fact that PyTorch bundles all of its CUDA dependencies in its own wheels and use the `nvidia/cuda:11.1-base-ubuntu20.04` images as the base images for PyTorch images.

```
* Use nvidia/cuda:11.1-base-ubuntu20.04 as base image for PyTorch images
   - PyTorch bundles all of its CUDA and CUDNN dependencies in wheels, so it doesn't need the devel base images
* Add 'torch' backend option and base-images to CI build matrix
   - Through use of exclude option, match backends to their base images in the build matrix
* Add BASE_IMAGE as build-arg to CI
* Amends PR #7
   - Allows for building and deploying of PyTorch images through CI/CD
```