### PR TITLE
feat: Update pyhf release to v0.6.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           DOCKER_IMAGE=pyhf/cuda
           VERSION=latest-${{ matrix.backend }}
-          PYHF_VERSION=0.6.1
+          PYHF_VERSION=0.6.2
           CUDA_VERSION=11.1
           FULL_TAG=${PYHF_VERSION}-${{ matrix.backend }}-cuda-${CUDA_VERSION}
           REPO_NAME=${{github.repository}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ SHELL [ "/bin/bash", "-c" ]
 
 WORKDIR /home/data
 
-ARG PYHF_VERSION=0.6.1
+ARG PYHF_VERSION=0.6.2
 ARG PYHF_BACKEND=jax
 # Set PATH to pickup virtualenv when it is unpacked
 ENV PATH=/usr/local/venv/bin:"${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ image:
 	docker build . \
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:11.1-cudnn8-devel-ubuntu20.04 \
-	--build-arg PYHF_VERSION=0.6.1 \
+	--build-arg PYHF_VERSION=0.6.2 \
 	--build-arg PYHF_BACKEND=jax \
 	-t pyhf/cuda:jax-debug-local \
-	-t pyhf/cuda:0.6.1-jax-cuda-11.1-debug-local
+	-t pyhf/cuda:0.6.2-jax-cuda-11.1-debug-local
 	docker system prune -f
 
 image-torch:
@@ -18,9 +18,9 @@ image-torch:
 	docker build . \
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=nvidia/cuda:11.1-base-ubuntu20.04 \
-	--build-arg PYHF_VERSION=0.6.1 \
+	--build-arg PYHF_VERSION=0.6.2 \
 	--build-arg PYHF_BACKEND=torch \
-	-t pyhf/cuda:0.6.1-torch-cuda-11.1-debug-local
+	-t pyhf/cuda:0.6.2-torch-cuda-11.1-debug-local
 	docker system prune -f
 
 image-cuda-101:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Example:
 
 ```
-docker pull pyhf/cuda:0.6.1-jax-cuda-11.1
+docker pull pyhf/cuda:0.6.2-jax-cuda-11.1
 ```
 
 ## Use
@@ -26,7 +26,7 @@ docker pull pyhf/cuda:0.6.1-jax-cuda-11.1
 To check that NVIDIA GPUS are being properly detected run
 
 ```
-docker run --rm --gpus all pyhf/cuda:0.6.1-jax-cuda-11.1 'nvidia-smi'
+docker run --rm --gpus all pyhf/cuda:0.6.2-jax-cuda-11.1 'nvidia-smi'
 ```
 
 and check if the [`nvidia-smi`](https://developer.nvidia.com/nvidia-system-management-interface) output appears correctly.
@@ -34,7 +34,7 @@ and check if the [`nvidia-smi`](https://developer.nvidia.com/nvidia-system-manag
 To run (interactively) using GPUs on the host machine:
 
 ```
-docker run --rm -ti --gpus all pyhf/cuda:0.6.1-jax-cuda-11.1
+docker run --rm -ti --gpus all pyhf/cuda:0.6.2-jax-cuda-11.1
 ```
 
 ## Tests
@@ -42,5 +42,5 @@ docker run --rm -ti --gpus all pyhf/cuda:0.6.1-jax-cuda-11.1
 To verify things are working on your host machine you can run
 
 ```
-docker run --rm --gpus all -v $PWD:$PWD -w $PWD pyhf/cuda:0.6.1-jax-cuda-11.1 'bash tests/test_backend.sh jax'
+docker run --rm --gpus all -v $PWD:$PWD -w $PWD pyhf/cuda:0.6.2-jax-cuda-11.1 'bash tests/test_backend.sh jax'
 ```


### PR DESCRIPTION
Update the `pyhf` release used by default to `v0.6.2`

```
* Update default pyhf release in Dockerfiles to v0.6.2
   - c.f. https://github.com/scikit-hep/pyhf/releases/tag/v0.6.2
```