### PR TITLE
fix: Add CuDNN version information to jaxlib install

### DIFF
--- a/install_backend.sh
+++ b/install_backend.sh
@@ -11,9 +11,9 @@ function install_jax_backend {
     # shellcheck disable=SC2153
     cuda_version=$(echo "${CUDA_VERSION}" | cut --delimiter . --fields -1)
     # Determine CuDNN version number
-    CUDNN_MAJOR="$(cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep '#define CUDNN_MAJOR' | awk '{print $NF}')"
-    CUDNN_MINOR="$(cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep '#define CUDNN_MINOR' | awk '{print $NF}')"
-    CUDNN_PATCHLEVEL="$(cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep '#define CUDNN_PATCHLEVEL' | awk '{print $NF}')"
+    CUDNN_MAJOR="$(cat /usr/include/x86_64-linux-gnu/cudnn_version_v*.h | grep '#define CUDNN_MAJOR' | awk '{print $NF}')"
+    CUDNN_MINOR="$(cat /usr/include/x86_64-linux-gnu/cudnn_version_v*.h | grep '#define CUDNN_MINOR' | awk '{print $NF}')"
+    CUDNN_PATCHLEVEL="$(cat /usr/include/x86_64-linux-gnu/cudnn_version_v*.h | grep '#define CUDNN_PATCHLEVEL' | awk '{print $NF}')"
     cudnn_version="${CUDNN_MAJOR}${CUDNN_MINOR}${CUDNN_PATCHLEVEL}"
     echo "jaxlib version: ${jaxlib_version}"
     echo "jaxlib+cuda version: ${jaxlib_version}+cuda${cuda_version}.cudnn${cudnn_version}"

--- a/install_backend.sh
+++ b/install_backend.sh
@@ -10,8 +10,11 @@ function install_jax_backend {
     jaxlib_version=$(python -c 'import jaxlib; print(jaxlib.__version__)')
     # shellcheck disable=SC2153
     cuda_version=$(echo "${CUDA_VERSION}" | cut -d . -f -2 | sed 's/\.//')
-    cudnn_version="805"
-    # cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep CUDNN_MAJOR --after-context 2
+    # Determine CuDNN version number
+    CUDNN_MAJOR="$(cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep '#define CUDNN_MAJOR' | awk '{print $NF}')"
+    CUDNN_MINOR="$(cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep '#define CUDNN_MINOR' | awk '{print $NF}')"
+    CUDNN_PATCHLEVEL="$(cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep '#define CUDNN_PATCHLEVEL' | awk '{print $NF}')"
+    cudnn_version="${CUDNN_MAJOR}${CUDNN_MINOR}${CUDNN_PATCHLEVEL}"
     echo "jaxlib version: ${jaxlib_version}"
     echo "jaxlib+cuda version: ${jaxlib_version}+cuda${cuda_version}.cudnn${cudnn_version}"
     python -m pip --no-cache-dir install --upgrade jax jaxlib=="${jaxlib_version}+cuda${cuda_version}.cudnn${cudnn_version}" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html

--- a/install_backend.sh
+++ b/install_backend.sh
@@ -10,9 +10,11 @@ function install_jax_backend {
     jaxlib_version=$(python -c 'import jaxlib; print(jaxlib.__version__)')
     # shellcheck disable=SC2153
     cuda_version=$(echo "${CUDA_VERSION}" | cut -d . -f -2 | sed 's/\.//')
+    cudnn_version="805"
+    # cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep CUDNN_MAJOR --after-context 2
     echo "jaxlib version: ${jaxlib_version}"
-    echo "jaxlib+cuda version: ${jaxlib_version}+cuda${cuda_version}"
-    python -m pip --no-cache-dir install --upgrade jax jaxlib=="${jaxlib_version}+cuda${cuda_version}" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
+    echo "jaxlib+cuda version: ${jaxlib_version}+cuda${cuda_version}.cudnn${cudnn_version}"
+    python -m pip --no-cache-dir install --upgrade jax jaxlib=="${jaxlib_version}+cuda${cuda_version}.cudnn${cudnn_version}" --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
 }
 
 function install_pytorch_backend {

--- a/install_backend.sh
+++ b/install_backend.sh
@@ -9,7 +9,7 @@ function install_jax_backend {
     python -m pip --no-cache-dir install --upgrade jax jaxlib
     jaxlib_version=$(python -c 'import jaxlib; print(jaxlib.__version__)')
     # shellcheck disable=SC2153
-    cuda_version=$(echo "${CUDA_VERSION}" | cut -d . -f -2 | sed 's/\.//')
+    cuda_version=$(echo "${CUDA_VERSION}" | cut --delimiter . --fields -1)
     # Determine CuDNN version number
     CUDNN_MAJOR="$(cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep '#define CUDNN_MAJOR' | awk '{print $NF}')"
     CUDNN_MINOR="$(cat /usr/include/x86_64-linux-gnu/cudnn_v*.h | grep '#define CUDNN_MINOR' | awk '{print $NF}')"
@@ -24,7 +24,7 @@ function install_pytorch_backend {
     local torch_version=1.9.0
     local cuda_version
 
-    cuda_version=$(echo "${CUDA_VERSION}" | cut -d . -f -2 | sed 's/\.//')
+    cuda_version=$(echo "${CUDA_VERSION}" | cut --delimiter . --fields -2 | sed 's/\.//')
     echo "torch+cuda version: ${torch_version}+cu${cuda_version}"
     python -m pip --no-cache-dir install torch=="${torch_version}+cu${cuda_version}" --find-links https://download.pytorch.org/whl/torch_stable.html
 }


### PR DESCRIPTION
```
* Determine available version of CuDNN and install that CUDA enabled version of jaxlib
   - Use /usr/include/x86_64-linux-gnu/cudnn_version_v*.h to get CuDNN version numbers
```